### PR TITLE
Add extra dependencies

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,10 +1,12 @@
 cairosvg>=2.6.0
 markdown-exec>=1.3.0
+markdown-include>=0.8.1
 mkdocs-gen-files>=0.4.0
 mkdocs-htmlproofer-plugin>=0.10.2
 mkdocs-material-extensions>=1.1.1
 mkdocs-material>=9.0.13
-mkdocs-minify-plugin
+mkdocs-minify-plugin>=0.6.2
+mkdocs-monorepo-plugin>=1.0.4
 mkdocs>=1.4.2
 mkdocstrings-python>=0.8.3
 mkdocstrings>=0.20.0

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -24,6 +24,7 @@ jinja2==3.1.2
 jsmin==3.0.1
 markdown==3.3.7
 markdown-exec==1.3.0
+markdown-include==0.8.1
 markupsafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.4.2
@@ -33,6 +34,7 @@ mkdocs-htmlproofer-plugin==0.10.3
 mkdocs-material==9.1.1
 mkdocs-material-extensions==1.1.1
 mkdocs-minify-plugin==0.6.2
+mkdocs-monorepo-plugin==1.0.4
 mkdocstrings==0.20.0
 mkdocstrings-python==0.8.3
 packaging==23.0
@@ -42,12 +44,14 @@ pycparser==2.21
 pygments==2.14.0
 pymdown-extensions==9.10
 python-dateutil==2.8.2
+python-slugify==8.0.1
 pyyaml==6.0
 pyyaml-env-tag==0.1
 regex==2022.10.31
 requests==2.28.2
 six==1.16.0
 soupsieve==2.4
+text-unidecode==1.3
 tinycss2==1.2.1
 urllib3==1.26.14
 watchdog==2.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,6 @@ ci:
     - pip-compile
     - schemas
   submodules: true
-exclude: >
-  (?x)^(
-    src/mkdocs_ansible/_version.py
-  )$
 repos:
   - repo: meta
     hooks:

--- a/src/mkdocs_ansible/__init__.py
+++ b/src/mkdocs_ansible/__init__.py
@@ -1,6 +1,6 @@
 """mkdocs-ansible theme."""
 try:
-    from ._version import version as __version__
+    from ._version import version as __version__  # type: ignore
 except ImportError:  # pragma: no cover
     __version__ = "0.1.dev1"
 


### PR DESCRIPTION
- add monorepo plugin, so we can control its version
- add markdown-include, which seems to be compatible with monorepo plugin