### PR TITLE
Ignore mkdocs_macros untyped call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,6 @@ python_version = "3.10"
 warn_unused_configs = true
 exclude = ['build']
 
-# https://github.com/fralau/mkdocs-macros-plugin/issues/219
-[[tool.mypy.overrides]]
-module = ["mkdocs_macros.plugin"]
-ignore_missing_imports = true
-
 [[tool.mypy.overrides]]
 module = ["mkdocs_ansible._version"]
 warn_unused_ignores = false

--- a/src/mkdocs_ansible/__init__.py
+++ b/src/mkdocs_ansible/__init__.py
@@ -37,4 +37,4 @@ def install_from_adt(name: str) -> str:
 def define_env(env: MacrosPlugin) -> None:
     """Declare environment for jinja2 templates for markdown."""
     for fn in [install_from_adt]:
-        env.macro(fn)
+        env.macro(fn)  # type: ignore[no-untyped-call]


### PR DESCRIPTION
The project is now registering as typed, but this specific call isn't, so we need to ignore it for now.