### PR TITLE
Pin down cairosvg<2.8.0 due to mkdocs-material bug

### DIFF
--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,4 +1,4 @@
-cairosvg>=2.7.1
+cairosvg>=2.7.1,<2.8.0 # temporary due to https://github.com/squidfunk/mkdocs-material/issues/8215
 linkchecker>=10.5.0
 markdown-exec>=1.10.0
 markdown-include>=0.8.1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,12 +2,17 @@
 name: tox
 
 on:
+  merge_group:
+    branches:
+      - "main"
   push:
     branches:
       - "main"
   pull_request:
     branches:
       - "main"
+  schedule:
+    - cron: "0 0 * * *"
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
Related: https://github.com/squidfunk/mkdocs-material/issues/8215
