### PR TITLE
Require python>=3.11

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -15,7 +15,6 @@ csscompressor==0.9.5      # via mkdocs-minify-plugin
 cssselect2==0.8.0         # via cairosvg
 defusedxml==0.7.1         # via cairosvg
 dnspython==2.7.0          # via linkchecker
-exceptiongroup==1.3.0     # via pytest
 execnet==2.1.1            # via pytest-xdist
 ghp-import==2.1.0         # via mkdocs
 griffe==1.7.3             # via mkdocstrings-python
@@ -63,8 +62,7 @@ soupsieve==2.7            # via beautifulsoup4
 super-collections==0.5.3  # via mkdocs-macros-plugin
 termcolor==3.1.0          # via mkdocs-macros-plugin
 tinycss2==1.4.0           # via cairosvg, cssselect2
-tomli==2.2.1              # via pytest
-typing-extensions==4.13.2  # via beautifulsoup4, exceptiongroup, mkdocstrings-python
+typing-extensions==4.13.2  # via beautifulsoup4
 urllib3==2.4.0            # via requests
 watchdog==6.0.0           # via mkdocs
 webencodings==0.5.1       # via cssselect2, tinycss2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
       TOXENV: pkg
 
     steps:
-      - name: Switch to using Python 3.10 by default
+      - name: Switch to using Python 3.11 by default
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install tox
         run: python3 -m pip install --user "tox>=4.0.0"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,7 +23,8 @@ jobs:
   tox:
     uses: ansible/team-devtools/.github/workflows/tox.yml@main
     with:
-      jobs_producing_coverage: 6
+      jobs_producing_coverage: 5
+      min_python: "3.11"
       other_names: |
         docs
         lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,20 +113,18 @@ repos:
         name: Check constraints files and requirements
         files: ^(pyproject\.toml|\.config/.*)$
         language: python
-        language_version: "3.10" # minimal we support officially
-        entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml
+        entry: uv pip compile -q --all-extras --python-version=3.11 --output-file=.config/constraints.txt pyproject.toml
         pass_filenames: false
         additional_dependencies:
-          - uv>=0.5.21
+          - uv>=0.6.6
       - id: lock
         name: Update requirements-lock.txt
         alias: lock
         always_run: true
-        entry: python3 -m uv pip compile -q --upgrade --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras
+        entry: python3 -m uv pip compile -q --python-version=3.11 --upgrade --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras
         files: ^(pyproject\.toml|\.config/.*)$
         language: python
-        language_version: "3.10" # minimal we support officially
         pass_filenames: false
         stages: [manual]
         additional_dependencies:
-          - uv>=0.5.21
+          - uv>=0.6.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: JavaScript",
   "Programming Language :: Python",
-  'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
@@ -29,7 +28,7 @@ license = {text = "MIT"}
 maintainers = [{"email" = "info@ansible.com", "name" = "Ansible by Red Hat"}]
 name = "mkdocs-ansible"
 readme = "docs/README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.entry-points."mkdocs.themes"]
 ansible = "mkdocs_ansible"
@@ -72,7 +71,7 @@ source = ["src"]
 [tool.mypy]
 exclude = "(.config|build|dist|test/local-content|site-packages|~/.pyenv|examples/playbooks/collections|plugins/modules)"
 # https://github.com/python/mypy/issues/12664
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 warn_unused_configs = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 requires =
     setuptools>=65.3
-    tox>=4.11.4
+    tox>=4.24.2
     tox-extra>=2.1
-    tox-uv>=1.20.2
+    tox-uv>=1.25
 env_list =
     py
     lint
@@ -26,6 +26,7 @@ pass_env =
     LANG
     LC_*
     NO_COLOR
+    PYTEST_*
     PYTEST_REQPASS
     PYTHON*
     PYTHONBREAKPOINT
@@ -52,17 +53,16 @@ commands_pre =
     sh -c "rm -f {env_dir}/.coverage.* 2>/dev/null || true"
 commands =
     coverage run -m pytest {posargs:}
-    {py,py310,py311,py312,py313}: sh -c "coverage combine -q --data-file={env_dir}/.coverage {env_dir}/.coverage.* && coverage xml --data-file={env_dir}/.coverage -o {env_dir}/coverage.xml --ignore-errors --fail-under=0 && COVERAGE_FILE={env_dir}/.coverage coverage lcov --fail-under=0 --ignore-errors -q && COVERAGE_FILE={env_dir}/.coverage coverage report --fail-under=0 --ignore-errors"
+    {py,py311,py312,py313}: sh -c "coverage combine -q --data-file={env_dir}/.coverage {env_dir}/.coverage.* && coverage xml --data-file={env_dir}/.coverage -o {env_dir}/coverage.xml --ignore-errors --fail-under=0 && COVERAGE_FILE={env_dir}/.coverage coverage lcov --fail-under=0 --ignore-errors -q && COVERAGE_FILE={env_dir}/.coverage coverage report --fail-under=0 --ignore-errors"
 allowlist_externals =
     sh
 editable = true
 
 [testenv:lint]
 description = Run all linters
-base_python = python3.10
 skip_install = true
 deps =
-    pre-commit>=4.0.1
+    pre-commit>=4.1
     pre-commit-uv>=4.1.4
     pytest>=7.2.2  # to updated schemas
     setuptools>=65.3
@@ -108,7 +108,6 @@ commands =
 
 [testenv:deps]
 description = Bump all test dependencies
-base_python = python3.10
 skip_install = true
 deps =
     {[testenv:lint]deps}


### PR DESCRIPTION
As cairosvg started to require python 3.11, we don't want to endup using various unmaintained older versions.