### PR TITLE
fix(security): downgrade build to 1.5.0 (1.5.1 was yanked)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ lint = [
   "tombi>=1.2.0",
   "yamllint>=1.38.0",
 ]
-pkg = ["build>=1.5.1", "pip>=26.1.2", "twine>=6.2.0"]
+pkg = ["build>=1.5.0,!=1.5.1", "pip>=26.1.2", "twine>=6.2.0"]
 
 [build-system]
 requires = [

--- a/uv.lock
+++ b/uv.lock
@@ -127,16 +127,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ lint = [
     { name = "yamllint", specifier = ">=1.38.0" },
 ]
 pkg = [
-    { name = "build", specifier = ">=1.5.1" },
+    { name = "build", specifier = ">=1.5.0,!=1.5.1" },
     { name = "pip", specifier = ">=26.1.2" },
     { name = "twine", specifier = ">=6.2.0" },
 ]


### PR DESCRIPTION
build 1.5.1 was yanked from PyPI (reason: breaking changes, will re-release as new major version). Exclude 1.5.1 and pin to 1.5.0 which is the latest non-yanked release. Flagged by the weekly supply chain audit.